### PR TITLE
add a new function:setup start training epoch

### DIFF
--- a/cosine_annealing.py
+++ b/cosine_annealing.py
@@ -7,8 +7,9 @@ class CosineAnnealingScheduler(Callback):
     """Cosine annealing scheduler.
     """
 
-    def __init__(self, T_max, eta_max, eta_min=0, verbose=0):
+    def __init__(self, T_max, eta_max, init_epoch=0, eta_min=0, verbose=0):
         super(CosineAnnealingScheduler, self).__init__()
+        self.init_epoch = init_epoch
         self.T_max = T_max
         self.eta_max = eta_max
         self.eta_min = eta_min
@@ -17,7 +18,7 @@ class CosineAnnealingScheduler(Callback):
     def on_epoch_begin(self, epoch, logs=None):
         if not hasattr(self.model.optimizer, 'lr'):
             raise ValueError('Optimizer must have a "lr" attribute.')
-        lr = self.eta_min + (self.eta_max - self.eta_min) * (1 + math.cos(math.pi * epoch / self.T_max)) / 2
+        lr = self.eta_min + (self.eta_max - self.eta_min) * (1 + math.cos(math.pi * (epoch - self.init_epoch) / self.T_max)) / 2
         K.set_value(self.model.optimizer.lr, lr)
         if self.verbose > 0:
             print('\nEpoch %05d: CosineAnnealingScheduler setting learning '


### PR DESCRIPTION
I use your function for my own code. But I use two stage for training. First training has epochs from 0 to 50, and the next has epochs from 50 to 200. I use CosineAnnealingScheduler in the second stage training. In your code, your function compute the learning rate from 0, but I need to compute from 50. So I add the function of setup the init_epoch in your code(default init_epoch=0) in order to make your code more functional to meet the needs of others.
Please check out my changes. In my code, my changes can work correctly. So if there are some mistakes in it, please let me know in time. Thanks.